### PR TITLE
Fixes and improvments

### DIFF
--- a/rake/rake.go
+++ b/rake/rake.go
@@ -96,9 +96,11 @@ func IsAcceptable(phrase string, minCharLength int, maxWordsLength int) bool {
 
 func findStopwordIndices(words []string, stopwords map[string]bool) []int {
 	result := []int{}
-	for i, word := range words {
-		if stopwords[word] {
-			result = append(result, i)
+	if stopwords != nil {
+		for i, word := range words {
+			if stopwords[word] {
+				result = append(result, i)
+			}
 		}
 	}
 	return result
@@ -264,8 +266,7 @@ func loadStopWords(stopWordFile string) []string {
 	return stopWords
 }
 
-func BuildStopWordMap(stopWordFilePath string) map[string]bool {
-	stopWordList := loadStopWords(stopWordFilePath)
+func BuildStopWordMap(stopWordList []string) map[string]bool {
 	stopWordMap := make(map[string]bool, len(stopWordList))
 	for _, word := range stopWordList {
 		stopWordMap[word] = true
@@ -296,13 +297,21 @@ type KeywordScore struct {
 }
 
 func NewRake(stopWordsPath string, minCharLength int, maxWordsLength int, minKeywordFrequency int) *Rake {
-	return &Rake{
-		stopWordsPath:       stopWordsPath,
-		stopWords:           BuildStopWordMap(stopWordsPath),
+	rake := &Rake{
 		minCharLength:       minCharLength,
 		maxWordsLength:      maxWordsLength,
 		minKeywordFrequency: minKeywordFrequency,
 	}
+
+	if stopWordsPath != "" {
+		rake.stopWords = BuildStopWordMap(loadStopWords(stopWordsPath))
+	}
+
+	return rake
+}
+
+func (rake *Rake) SetStopWords(stopWordsList []string) {
+	rake.stopWords = BuildStopWordMap(stopWordsList)
 }
 
 func (rake *Rake) Run(text string) []KeywordScore {

--- a/rake/rake.go
+++ b/rake/rake.go
@@ -98,7 +98,7 @@ func findStopwordIndices(words []string, stopwords map[string]bool) []int {
 	result := []int{}
 	if stopwords != nil {
 		for i, word := range words {
-			if stopwords[word] {
+			if stopwords[strings.ToLower(word)] {
 				result = append(result, i)
 			}
 		}
@@ -269,7 +269,7 @@ func loadStopWords(stopWordFile string) []string {
 func BuildStopWordMap(stopWordList []string) map[string]bool {
 	stopWordMap := make(map[string]bool, len(stopWordList))
 	for _, word := range stopWordList {
-		stopWordMap[word] = true
+		stopWordMap[strings.ToLower(word)] = true
 	}
 	return stopWordMap
 }

--- a/rake/rake.go
+++ b/rake/rake.go
@@ -109,7 +109,7 @@ func findStopwordIndices(words []string, stopwords map[string]bool) []int {
 func GenerateCandidateKeywords(sentenceList []string, stopwords map[string]bool, minCharLength int, maxWordsLength int) []string {
 	phraseList := []string{}
 	for _, s := range sentenceList {
-		words := strings.Split(s, " ")
+		words := strings.Fields(s)
 		stopwordIndices := findStopwordIndices(words, stopwords)
 
 		if len(stopwordIndices) > 0 {
@@ -257,7 +257,7 @@ func loadStopWords(stopWordFile string) []string {
 		line = strings.ToLower(strings.TrimSpace(line))
 		if strings.Index(line, "#") != 0 {
 			// in case more than one per line
-			for _, word := range strings.Split(line, " ") {
+			for _, word := range strings.Fields(line) {
 				stopWords = append(stopWords, word)
 			}
 


### PR DESCRIPTION
1. Currently the implementation does not support non-latin characters.
2. The only possible way to pass stop words is a file and it is required. It is annoying, especially, if i don't store them in a file, what should i do then?
3. strings.Fields(str) is more reliable than strings.Split(str, " "). Example: https://play.golang.org/p/qFNRZl6F9I
4. A comparison of words and stop words is a bit dishonest.
5. A sentence separation is improved and simplified. 

P.S. i've used gofmt in the editor and made some extra diffs in the first commit.